### PR TITLE
Make POSTGRES_DBNAME an env variable

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,8 @@ require('dotenv').load({ silent: true });
 
 const {
   SERVER_PORT = 3000,
-  POSTGRES_URL = 'postgres://postgres:postgres@postgres:5432/postgres',
+  POSTGRES_DBNAME = 'wdm',
+  POSTGRES_URL = 'postgres://postgres:postgres@postgres:5432/',
   NEO_URL = 'bolt://neo4j',
   BASE_URL = 'http://localhost:2222',
 } = process.env;
@@ -10,6 +11,7 @@ const {
 module.exports = {
     SERVER_PORT,
     POSTGRES_URL,
+    POSTGRES_DBNAME,
     NEO_URL,
     BASE_URL
 };

--- a/src/pg/connection.js
+++ b/src/pg/connection.js
@@ -1,7 +1,7 @@
 const Sequelize = require('sequelize');
-const { POSTGRES_URL } = require('../config');
+const { POSTGRES_URL, POSTGRES_DBNAME } = require('../config');
 
-const sequelize = new Sequelize(POSTGRES_URL);
+const sequelize = new Sequelize(`${POSTGRES_URL}${POSTGRES_DBNAME}`);
 
 sequelize.authenticate()
   .then(err => {


### PR DESCRIPTION
This PR fixes the config to have a default database name `wdm` for Postgres. It also allows you to set the name from the environment or a `.env` file like so:
```bash
POSTGRES_DBNAME="postgres"
``` 